### PR TITLE
Potential fix for code scanning alert no. 59: Uncontrolled data used in path expression

### DIFF
--- a/src/fa-helper/config/get_config_dir.c
+++ b/src/fa-helper/config/get_config_dir.c
@@ -8,6 +8,47 @@
 */
 #include "fastboot_assistant.h"
 
+// Validate that the string is a single, safe path component (e.g. a user name).
+// It must not be empty, must not contain path separators, and must not contain "..".
+static int is_safe_single_path_component(const char *s)
+{
+    size_t len;
+
+    if (s == NULL) {
+        return 0;
+    }
+
+    len = strlen(s);
+    if (len == 0 || len > 255) {
+        return 0;
+    }
+
+    if (strchr(s, '/') != NULL || strchr(s, '\\') != NULL) {
+        return 0;
+    }
+
+    if (strstr(s, "..") != NULL) {
+        return 0;
+    }
+
+    return 1;
+}
+
+// Basic validation for HOME-like directory variables.
+// Require a non-empty absolute path (starting with '/').
+static int is_safe_home_dir(const char *s)
+{
+    if (s == NULL) {
+        return 0;
+    }
+
+    if (s[0] != '\0' && s[0] == '/') {
+        return 1;
+    }
+
+    return 0;
+}
+
 /** function that get the config dir
 *
 * Usage:
@@ -20,7 +61,7 @@ void get_config_dir(char *config_folder, size_t size)
     if (directory_exists("/mnt/c/Users")) 
     {
     	const char* user = getenv("USER");
-    	if (user && config_folder && size > 0) 
+    	if (user && config_folder && size > 0 && is_safe_single_path_component(user)) 
     	{
         	snprintf(config_folder, size, "/mnt/c/Users/%s/.config/fastboot-assistant", user);
     	} 
@@ -32,14 +73,14 @@ void get_config_dir(char *config_folder, size_t size)
     
     	else 
     	{
-        	LOGE("Invalid arguments provided to get_config_file_path.");
+        	LOGE("Invalid or unsafe USER value provided to get_config_file_path.");
     	}
     	return;
     }
     
     // standard linux
     const char *home_dir = getenv("HOME"); 
-    if (home_dir && config_folder && size > 0) 
+    if (home_dir && config_folder && size > 0 && is_safe_home_dir(home_dir)) 
     {
         snprintf(config_folder, size, "%s/.config/fastboot-assistant", home_dir);
     } 
@@ -51,6 +92,6 @@ void get_config_dir(char *config_folder, size_t size)
     
     else 
     {
-        LOGE("Invalid arguments provided to get_config_file_path.");
+        LOGE("Invalid or unsafe HOME value provided to get_config_file_path.");
     }
 }

--- a/src/fa-helper/config/get_config_dir.c
+++ b/src/fa-helper/config/get_config_dir.c
@@ -8,47 +8,6 @@
 */
 #include "fastboot_assistant.h"
 
-// Validate that the string is a single, safe path component (e.g. a user name).
-// It must not be empty, must not contain path separators, and must not contain "..".
-static int is_safe_single_path_component(const char *s)
-{
-    size_t len;
-
-    if (s == NULL) {
-        return 0;
-    }
-
-    len = strlen(s);
-    if (len == 0 || len > 255) {
-        return 0;
-    }
-
-    if (strchr(s, '/') != NULL || strchr(s, '\\') != NULL) {
-        return 0;
-    }
-
-    if (strstr(s, "..") != NULL) {
-        return 0;
-    }
-
-    return 1;
-}
-
-// Basic validation for HOME-like directory variables.
-// Require a non-empty absolute path (starting with '/').
-static int is_safe_home_dir(const char *s)
-{
-    if (s == NULL) {
-        return 0;
-    }
-
-    if (s[0] != '\0' && s[0] == '/') {
-        return 1;
-    }
-
-    return 0;
-}
-
 /** function that get the config dir
 *
 * Usage:

--- a/src/fa-helper/config/secure_path_home.c
+++ b/src/fa-helper/config/secure_path_home.c
@@ -1,0 +1,53 @@
+/**
+* secure_path_home.c
+*
+* (C) Copyright 2025 @NachtsternBuild
+*
+* License: GNU GENERAL PUBLIC LICENSE Version 3
+*
+*/
+
+/**
+* @brief Validate that the string is a single, safe path component (e.g. a user name).
+* It must not be empty, must not contain path separators, and must not contain "..".
+*/ 
+int is_safe_single_path_component(const char *s)
+{
+    size_t len;
+
+    if (s == NULL) {
+        return 0;
+    }
+
+    len = strlen(s);
+    if (len == 0 || len > 255) {
+        return 0;
+    }
+
+    if (strchr(s, '/') != NULL || strchr(s, '\\') != NULL) {
+        return 0;
+    }
+
+    if (strstr(s, "..") != NULL) {
+        return 0;
+    }
+
+    return 1;
+}
+
+/** 
+* @brief Basic validation for HOME-like directory variables.
+* Require a non-empty absolute path (starting with '/').
+*/
+int is_safe_home_dir(const char *s)
+{
+    if (s == NULL) {
+        return 0;
+    }
+
+    if (s[0] != '\0' && s[0] == '/') {
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/fa-helper/config/secure_path_home.c
+++ b/src/fa-helper/config/secure_path_home.c
@@ -6,6 +6,7 @@
 * License: GNU GENERAL PUBLIC LICENSE Version 3
 *
 */
+#include "fastboot_assistant.h"
 
 /**
 * @brief Validate that the string is a single, safe path component (e.g. a user name).

--- a/src/include/fa_helper.h
+++ b/src/include/fa_helper.h
@@ -38,6 +38,14 @@ const char* get_execution_environment();
 // set configs for application env
 void application_environment();
 
+/**
+* functions to ensure save paths 
+*/
+// validate that the string is a single, safe path component
+int is_safe_single_path_component(const char *s);
+// set that home dir is safe
+int is_safe_home_dir(const char *s);
+
 /** 
 * function, that get the path of the config file
 *


### PR DESCRIPTION
Potential fix for [https://github.com/NachtsternBuild/fastboot-assistant/security/code-scanning/59](https://github.com/NachtsternBuild/fastboot-assistant/security/code-scanning/59)

General approach: Validate or constrain the environment-variable–derived components (`USER` and `HOME`) before using them in path construction, ensuring they do not contain path separators or traversal sequences and are not empty. For `USER`, the natural constraint is that it is a single path component (no `/` or `\`, no `..`), because it is inserted between fixed path segments. For `HOME`, we can at least ensure it is an absolute path (starts with `/`) and not empty; more advanced checks (like `realpath` and base-directory enforcement) would change behavior more, so we avoid that.

Best concrete fix: In `get_config_dir.c`, introduce small static helper functions that validate `USER` and `HOME` contents, then only call `snprintf` when validation passes. If validation fails, log an error and avoid writing anything into `config_folder`, leaving the caller to see an empty or unchanged buffer (which, combined with logging, is safer than proceeding with a potentially malicious path). No change is needed in `main.c` beyond this, because `setup_file` is entirely derived from `fish_path` and constant suffixes—once `get_config_dir` guarantees `fish_path` is safe, the subsequent usage in `main.c` becomes safe as well.

Concretely:

- Edit `src/fa-helper/config/get_config_dir.c`:
  - Add two `static` validator functions above `get_config_dir`:
    - `is_safe_single_path_component(const char *s)`:
      - Returns false if `s` is `NULL`, empty, longer than some reasonable limit (e.g. 255), contains `/` or `\`, or contains `".."` as a substring.
    - `is_safe_home_dir(const char *s)`:
      - Returns false if `s` is `NULL` or empty, or if it does not start with `/`. (We avoid over-restricting legitimate home dirs.)
  - In the WSL branch, after calling `getenv("USER")`, also check `is_safe_single_path_component(user)` and only do `snprintf` when it is safe. Otherwise, log an error and return without modifying `config_folder`.
  - In the standard Linux branch, after `getenv("HOME")`, also check `is_safe_home_dir(home_dir)` and only then construct the path. If validation fails, log and return without writing to `config_folder`.

- `src/functions/main.c` can remain unchanged; its taintedness will be removed once `get_config_dir` sanitizes its output. We do not introduce new external dependencies; all functions use standard C library functions already available via `fastboot_assistant.h` includes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
